### PR TITLE
Feature/card UI polish

### DIFF
--- a/src/components/app-shell.vue
+++ b/src/components/app-shell.vue
@@ -14,7 +14,12 @@
 
     <section>
       <div class="row">
-        <startup-list :list="computedStartups" />
+        <template v-if="computedStartups.length > 0">
+          <startup-list :list="computedStartups" />
+        </template>
+        <template v-else>
+          <not-found />
+        </template>
       </div>
     </section>
   </main>
@@ -32,6 +37,7 @@ import {
 // components
 import StartupListFilters from '@/components/startup-list-filters.vue';
 import StartupList from '@/components/startup-list.vue';
+import NotFound from '@/components/not-found.vue';
 
 // models
 import { Category, ICategory, IStartup } from '@/models';
@@ -40,7 +46,8 @@ export default defineComponent({
   name: 'AppShell',
   components: {
     StartupListFilters,
-    StartupList
+    StartupList,
+    NotFound
   },
   setup() {
     // common

--- a/src/components/not-found.vue
+++ b/src/components/not-found.vue
@@ -24,17 +24,15 @@ export default defineComponent({
   margin: 2rem auto;
   padding: 3rem 1.5rem;
   text-align: center;
-  background-color: #f8d7da;
-  border: 1px solid #f5c6cb;
   border-radius: 5px;
 }
 
 .not-found-container h2 {
-  color: #721c24;
+  color: #e02134;
 }
 
 .not-found-container p {
-  color: #721c24;
+  color: #e02134;
   margin-top: 10px;
 }
 </style>

--- a/src/components/not-found.vue
+++ b/src/components/not-found.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="not-found-container">
+    <h2 class="text-center">No Results Found</h2>
+    <p class="text-center">
+      Sorry, we couldn't find any results matching your criteria.
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'NotFound'
+});
+</script>
+
+<style scoped>
+.not-found-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 2rem auto;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  border-radius: 5px;
+}
+
+.not-found-container h2 {
+  color: #721c24;
+}
+
+.not-found-container p {
+  color: #721c24;
+  margin-top: 10px;
+}
+</style>

--- a/src/components/startup-bio.vue
+++ b/src/components/startup-bio.vue
@@ -7,7 +7,7 @@
       <p class="text-muted mb-1">{{ startup.location }}</p>
       <div class="row align-items-center justify-content-between">
         <div class="col">
-          <p class="text-muted small">❌ {{ startup.shutdownDate }}</p>
+          <p class="shutdown text-muted small">❌ {{ startup.shutdownDate }}</p>
         </div>
         <div class="col">
           <p class="text-muted text-end small">
@@ -18,11 +18,7 @@
       <p class="mt-2">
         Founded in {{ startup.founded }}.
         {{ truncatedDescription }}
-        <span v-if="showReadMoreLink">
-          <a class="read-more-link" :href="startup.newsSource" target="_blank"
-            >Read more</a
-          >
-        </span>
+        <span v-if="showDots">... </span>
       </p>
       <p class="text-muted small mt-3">
         Source:
@@ -53,7 +49,7 @@ export default defineComponent({
   },
   data() {
     return {
-      showReadMoreLink: false,
+      showDots: false,
       truncatedDescription: '',
     };
   },
@@ -65,8 +61,8 @@ export default defineComponent({
   },
   methods: {
     truncateDescription() {
-      const maxLength = 80;
-      this.showReadMoreLink = this.startup.description.length > maxLength;
+      const maxLength = 120;
+      this.showDots = this.startup.description.length > maxLength;
       this.truncatedDescription = this.startup.description.slice(0, maxLength);
     },
   },
@@ -81,13 +77,26 @@ export default defineComponent({
   background-color: #f8d7da;
   border: 1px solid #f5c6cb;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-  height: 300px;
+  min-height: 300px;
+  transition: all 0.3s ease;
+}
+
+.startup-card:hover {
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  transform: translateY(-5px);
 }
 .h4 {
   display: inline-block;
   border-bottom: 1px solid;
 }
 
+.shutdown {
+  background: #e6c4c7;
+  border-radius: 5px;
+  padding: 0.25rem;
+  width: fit-content;
+  
+}
 .read-more-link {
   color: #007bff;
   cursor: pointer;
@@ -96,5 +105,18 @@ export default defineComponent({
 
 .read-more-link:hover {
   text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .startup-card {
+    min-height: 100%;
+  }
+}
+
+@media (max-width: 576px) {
+  .startup-card {
+    width: 90%;
+    margin: auto;
+  }
 }
 </style>

--- a/src/components/startup-bio.vue
+++ b/src/components/startup-bio.vue
@@ -17,8 +17,7 @@
       </div>
       <p class="mt-2">
         Founded in {{ startup.founded }}.
-        {{ truncatedDescription }}
-        <span v-if="showDots">... </span>
+        {{ startup.description }}
       </p>
       <p class="text-muted small mt-3">
         Source:
@@ -46,26 +45,7 @@ export default defineComponent({
       type: Object as () => IStartup,
       required: true
     }
-  },
-  data() {
-    return {
-      showDots: false,
-      truncatedDescription: '',
-    };
-  },
-  watch: {
-    'startup.description': 'truncateDescription',
-  },
-  mounted() {
-    this.truncateDescription();
-  },
-  methods: {
-    truncateDescription() {
-      const maxLength = 120;
-      this.showDots = this.startup.description.length > maxLength;
-      this.truncatedDescription = this.startup.description.slice(0, maxLength);
-    },
-  },
+  }
 });
 </script>
 
@@ -74,10 +54,8 @@ export default defineComponent({
   padding: 1rem;
   margin-bottom: 1rem;
   border-radius: 5px;
-  background-color: #f8d7da;
-  border: 1px solid #f5c6cb;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-  min-height: 300px;
+  min-height: 320px;
   transition: all 0.3s ease;
 }
 
@@ -91,20 +69,10 @@ export default defineComponent({
 }
 
 .shutdown {
-  background: #e6c4c7;
+  background: #f0eded;
   border-radius: 5px;
   padding: 0.25rem;
-  width: fit-content;
-  
-}
-.read-more-link {
-  color: #007bff;
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-.read-more-link:hover {
-  text-decoration: none;
+  width: fit-content; 
 }
 
 @media (max-width: 768px) {

--- a/src/components/startup-bio.vue
+++ b/src/components/startup-bio.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="px-md-3">
-    <div>
+  <div>
+    <div class="startup-card">
       <a target="_blank" :href="startup.newsSource">
         <h2 class="h4">{{ startup.name }}</h2>
       </a>
@@ -17,7 +17,12 @@
       </div>
       <p class="mt-2">
         Founded in {{ startup.founded }}.
-        {{ startup.description }}
+        {{ truncatedDescription }}
+        <span v-if="showReadMoreLink">
+          <a class="read-more-link" :href="startup.newsSource" target="_blank"
+            >Read more</a
+          >
+        </span>
       </p>
     </div>
   </div>
@@ -36,13 +41,51 @@ export default defineComponent({
       type: Object as () => IStartup,
       required: true
     }
-  }
+  },
+  data() {
+    return {
+      showReadMoreLink: false,
+      truncatedDescription: '',
+    };
+  },
+  watch: {
+    'startup.description': 'truncateDescription',
+  },
+  mounted() {
+    this.truncateDescription();
+  },
+  methods: {
+    truncateDescription() {
+      const maxLength = 80;
+      this.showReadMoreLink = this.startup.description.length > maxLength;
+      this.truncatedDescription = this.startup.description.slice(0, maxLength);
+    },
+  },
 });
 </script>
 
 <style lang="scss" scoped>
+.startup-card {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 5px;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  height: 300px;
+}
 .h4 {
   display: inline-block;
   border-bottom: 1px solid;
+}
+
+.read-more-link {
+  color: #007bff;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.read-more-link:hover {
+  text-decoration: none;
 }
 </style>

--- a/src/components/startup-list.vue
+++ b/src/components/startup-list.vue
@@ -31,9 +31,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.startup-container {
-  margin: auto;
-}
 
 @media (max-width: 992px) {
   .startup-container {

--- a/src/components/startup-list.vue
+++ b/src/components/startup-list.vue
@@ -1,5 +1,10 @@
 <template>
-  <div v-for="(item, index) in list" :key="index" class="col-md-4 mt-5">
+  <div
+    v-for="(item, index) in list"
+    :key="index"
+    class="
+    startup-container mt-5 col-12 col-sm-6 col-md-5 col-lg-4
+    ">
     <startup-bio :startup="item" />
   </div>
 </template>
@@ -26,3 +31,9 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.startup-container {
+  margin: auto;
+}
+</style>

--- a/src/components/startup-list.vue
+++ b/src/components/startup-list.vue
@@ -2,9 +2,7 @@
   <div
     v-for="(item, index) in list"
     :key="index"
-    class="
-    startup-container mt-5 col-12 col-sm-6 col-md-5 col-lg-4
-    ">
+    class="startup-container mt-5 col-12 col-sm-8 col-md-5 col-lg-4">
     <startup-bio :startup="item" />
   </div>
 </template>
@@ -35,5 +33,17 @@ export default defineComponent({
 <style lang="scss" scoped>
 .startup-container {
   margin: auto;
+}
+
+@media (max-width: 992px) {
+  .startup-container {
+    width: 50%;
+  }
+}
+
+@media (max-width: 768px) {
+  .startup-container {
+    width: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
[Netlify Demo Link](https://cheery-dasik-1bf627.netlify.app)

This PR adds the following:

1. Modified the Startup card UI styles
2. Modified the grid layout to properly fit all screen sizes
3. Added a function to truncate the bio card description text (This was done to maintain a uniform card height on all screens)
4. Added a NotFound UI for when search result is empty

**FUTURE MODIFICATION SUGGESTIONS**

- Add a startup details page where to display all details of that startup (i.e all that is left of it anyways).
- Pagination as against the current infinite scroll
- Integrate a database to be able automate the process of adding graveyard startups. This will also help to reduce human errors as someone might want to delibrately add falsified information. 
- Very importantly, we need to add a VERY LARGE DISCLAIMER at the footer `e get why`.

![Screenshot (167)](https://github.com/slightlynerd/startupgraveyard.africa/assets/99312664/b570dc6d-1162-4600-b6e0-9b5d6ce4ccdf)
![Screenshot (168)](https://github.com/slightlynerd/startupgraveyard.africa/assets/99312664/af97cad8-9d47-4f2b-aaf0-94ba955e2e22)
![Screenshot (169)](https://github.com/slightlynerd/startupgraveyard.africa/assets/99312664/2296a672-a71b-4fe7-b072-c7af336771d8)
![Screenshot (170)](https://github.com/slightlynerd/startupgraveyard.africa/assets/99312664/16c72f36-55f5-4618-9064-e1b12ef72325)
