### PR TITLE
Add recent blog posts sidebar to the blog article page

### DIFF
--- a/pages/blog/[id].vue
+++ b/pages/blog/[id].vue
@@ -60,7 +60,8 @@ const { $firestore } = useNuxtApp();
 const route = useRoute();
 
 // constants
-const MIN_BLOG_POSTS = 4;
+const MAX_RECENT_POSTS = 3;
+const NO_OF_POSTS_TO_FETCH = 4;
 
 // refs
 const datetime = ref<string>();
@@ -110,7 +111,7 @@ onMounted(async () => {
   const q = query(
     collection($firestore, FirestoreCollection.Blog),
     orderBy('createdAt', 'desc'),
-    limit(MIN_BLOG_POSTS)
+    limit(NO_OF_POSTS_TO_FETCH)
   );
   const querySnapshot = await getDocs(q);
   recentBlogPosts.value = [];
@@ -128,7 +129,9 @@ onMounted(async () => {
     }
   });
 
-  recentBlogPosts.value = recentBlogPosts.value.slice(0, 3);
+  if (recentBlogPosts.value?.length > MAX_RECENT_POSTS) {
+    recentBlogPosts.value = recentBlogPosts.value.slice(0, MAX_RECENT_POSTS);
+  }
 });
 
 useHead({

--- a/pages/blog/[id].vue
+++ b/pages/blog/[id].vue
@@ -205,7 +205,7 @@ article {
   .blog-container {
     display: flex;
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 992px) {
       flex-direction: column;
     }
   }
@@ -266,7 +266,7 @@ article {
     margin-left: 2rem;
     margin-top: 2rem;
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 992px) {
       margin-left: 0;
       margin-top: 4rem;
     }

--- a/pages/blog/[id].vue
+++ b/pages/blog/[id].vue
@@ -131,6 +131,8 @@ onMounted(async () => {
       });
     }
   });
+
+  recentBlogPosts.value = recentBlogPosts.value.slice(0, 3);
 });
 
 useHead({

--- a/pages/blog/[id].vue
+++ b/pages/blog/[id].vue
@@ -1,34 +1,34 @@
 <template>
-  <article
-    :style="{ marginBottom: !isMobile ? `${blogContentHeight}px` : 0 }"
-  >
+  <article>
     <img
       v-if="blogData?.data.headerImage"
       class="blog-image"
       :src="blogData.data.headerImage.url"
       :alt="blogData?.data.headerImage?.alt || blogData?.data.title"
     >
-    <div ref="blogContentRef" class="blog-container">
-      <h1 class="mb-3">
-        {{ blogData?.data.title }}
-      </h1>
-      <p class="mb-0">
-        Written By: <span class="text-muted">{{ blogData?.data.author }}</span>
-      </p>
-      <p class="mb-3">
-        <time :datetime="datetime">
-          Published on:
-          <span class="text-muted">{{ blogData?.data.createdAt }}</span>
-        </time>
-      </p>
-      <div
-        class="content"
-        v-html="sanitizeHtmlContent(blogData?.data.bodyContent)"
-      />
-      <h6 class="mt-5">
-        Share this article
-      </h6>
-      <share-buttons :blog-data="blogData?.data" />
+    <div class="blog-container">
+      <div class="blog-content">
+        <h1 class="mb-3">
+          {{ blogData?.data.title }}
+        </h1>
+        <p class="mb-0">
+          Written By: <span class="text-muted">{{ blogData?.data.author }}</span>
+        </p>
+        <p class="mb-3">
+          <time :datetime="datetime">
+            Published on:
+            <span class="text-muted">{{ blogData?.data.createdAt }}</span>
+          </time>
+        </p>
+        <div
+          class="content"
+          v-html="sanitizeHtmlContent(blogData?.data.bodyContent)"
+        />
+        <h6 class="mt-5">
+          Share this article
+        </h6>
+        <share-buttons :blog-data="blogData?.data" />
+      </div>
     </div>
   </article>
 </template>
@@ -44,7 +44,6 @@ import {
   FirestoreCollection,
   SANITIZE_HTML_OPTIONS,
   type IBlog,
-  MD_BREAKPOINT,
   META_DESCRIPTION_LENGTH
 } from '~/models';
 
@@ -53,22 +52,12 @@ const { $firestore } = useNuxtApp();
 const route = useRoute();
 
 // refs
-const blogContentRef = ref<HTMLElement | undefined>();
-const blogContentHeight = ref<number | undefined>(
-  blogContentRef.value?.offsetHeight
-);
 const datetime = ref<string>();
-const isMobile = ref<boolean>(false);
 const metaDescription = ref<string>('');
 
 // methods
 function sanitizeHtmlContent (content?: string): string {
   return content ? sanitizeHtml(content, SANITIZE_HTML_OPTIONS) : '';
-}
-
-function onResize (): void {
-  isMobile.value = window.innerWidth <= MD_BREAKPOINT;
-  blogContentHeight.value = blogContentRef.value?.offsetHeight;
 }
 
 // fetch blog data
@@ -102,22 +91,6 @@ const { data: blogData } = await useAsyncData(route.params.id.toString(), async 
   } catch (error) {
     // TODO: handle error
   }
-});
-
-// lifecycle hooks
-onMounted(() => {
-  nextTick(() => {
-    // TODO: add styles to fix footer to bottom of article to replace this workaround
-    blogContentHeight.value = blogContentRef.value?.offsetHeight;
-  });
-
-  // set initial mobile state
-  onResize();
-  window.addEventListener('resize', onResize);
-});
-
-onUnmounted(() => {
-  window.removeEventListener('resize', onResize);
 });
 
 useHead({
@@ -188,21 +161,29 @@ article {
   }
 
   .blog-container {
-    position: absolute;
-    top: 20rem;
+    display: flex;
+
+    @media screen and (max-width: 768px) {
+      flex-direction: column;
+    }
+  }
+
+  .blog-content {
+    position: relative;
     max-width: 60%;
     background-color: $sg-secondary-color;
     padding: 3rem;
     margin-left: 2rem;
+    margin-top: -4rem;
 
     @media screen and (max-width: 992px) {
       max-width: 75%;
     }
 
     @media screen and (max-width: 768px) {
-      position: initial;
       max-width: 100%;
       margin-left: 0;
+      margin-top: 0;
       padding: 2rem;
     }
 

--- a/pages/blog/[id].vue
+++ b/pages/blog/[id].vue
@@ -6,7 +6,7 @@
       :src="blogData.data.headerImage.url"
       :alt="blogData?.data.headerImage?.alt || blogData?.data.title"
     >
-    <div class="blog-container">
+    <div class="row gx-0">
       <div class="blog-content">
         <h1 class="mb-3">
           {{ blogData?.data.title }}
@@ -29,16 +29,12 @@
         </h6>
         <share-buttons :blog-data="blogData?.data" />
       </div>
-      <div class="blog-sidebar">
+      <div class="blog-sidebar col-lg-4">
         <p class="h6 text-uppercase fw-bold mb-3">
           Recent Posts
         </p>
-        <div class="blog-recent">
-          <blog-card
-            v-for="blog in recentBlogPosts"
-            :key="blog.id"
-            :blog
-          />
+        <div class="row gy-4 gx-0">
+          <blog-card v-for="blog in recentBlogPosts" :key="blog.id" :blog />
         </div>
       </div>
     </div>
@@ -202,14 +198,6 @@ article {
     object-fit: cover;
   }
 
-  .blog-container {
-    display: flex;
-
-    @media screen and (max-width: 992px) {
-      flex-direction: column;
-    }
-  }
-
   .blog-content {
     position: relative;
     max-width: 60%;
@@ -219,10 +207,6 @@ article {
     margin-top: -4rem;
 
     @media screen and (max-width: 992px) {
-      max-width: 75%;
-    }
-
-    @media screen and (max-width: 768px) {
       max-width: 100%;
       margin-left: 0;
       margin-top: 0;
@@ -270,12 +254,6 @@ article {
       margin-left: 0;
       margin-top: 4rem;
     }
-  }
-
-  .blog-recent {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
   }
 }
 </style>


### PR DESCRIPTION
Closes #24 
Closes #23 

I also removed the hacky footer logic on the blog page because it made adding the sidebar easier.
I get the last 4 blog posts and filter out the current post so there's always three blog posts on the right.